### PR TITLE
fix regexp in const passwordPatterns

### DIFF
--- a/libs/utils/src/validators/password-patterns.ts
+++ b/libs/utils/src/validators/password-patterns.ts
@@ -1,5 +1,5 @@
 export const passwordPatterns = {
   middleStrength: new RegExp(
-    '^(?=.*[A-Z])(?=.*[!@#$&*])(?=.*[0-9])(?=.*[a-z].*[a-z].*[a-z]).{8}$',
+    '^(?=.*[A-Z])(?=.*[!@#$&*])(?=.*[0-9])(?=.*[a-z].*[a-z].*[a-z]).{8,}$',
   ),
 };


### PR DESCRIPTION
- The user was unable to create a password, even while following the "strong password" requirements;

- An error was found in the RegExp in passwordPatterns.ts, same name const;

- The error was fixed, and strong password creation now follows the requirements and prevents the creation of passwords outside the parameters.